### PR TITLE
add some info/links in desktop forum widget 

### DIFF
--- a/Resources/views/Forum/forumsDesktopWidget.html.twig
+++ b/Resources/views/Forum/forumsDesktopWidget.html.twig
@@ -5,18 +5,49 @@
             {% for message in messages %}
                 <li class="list-group-item">
                     <div class="list-group-item-text">
-                        <a class="link-subject"
-                            href="{{ _path('claro_forum_messages', {'subject': message.getSubject().getId() }) }}"
-                        >
-                            {{ message.getSubject().getTitle() }}
-                        </a>
-                        <p>{{ message.getContent()|raw }}</p>
-                        <p class="text-muted">{{ 'forum_last_message_owner'|trans({}, 'widget') }} {{ message.getCreator().getFirstName() }} {{  message.getCreator().getLastName() }} {{ message.getCreationDate()| timeAgo }}</p>
+                        <p>{{ message.getContent()| truncate(400, true, " [...]") | raw }}</p>
+                        <ul class="breadcrumb">
+                            <span class="text-muted">
+                                {{ 'forum_last_message_owner'|trans({}, 'widget') }} {{ message.getCreator().getFirstName() }} {{  message.getCreator().getLastName() }} {{ message.getCreationDate()| timeAgo }} dans&nbsp;
+                            </span>
+                            <li>
+                                <a 
+                                    title="{{ message.subject.category.forum.resourceNode.workspace.name}}" 
+                                    href="{{ path('claro_workspace_open', {'workspaceId': message.subject.category.forum.resourceNode.workspace.id, 'toolName': 'home'}) }}"
+                                >
+                                    {{ message.subject.category.forum.resourceNode.workspace.name | truncate(20) }}
+                                </a>
+                            </li>
+                            <li>
+                                <a 
+                                    title="{{ message.subject.category.forum.resourceNode.name}}" 
+                                    href="{{ path('claro_forum_categories', { 'forum': message.subject.category.forum.id }) }}"
+                                >
+                                    {{ message.subject.category.forum.resourceNode.name | truncate(20) }}
+                                </a>
+                            </li>
+                             <li>
+                                <a 
+                                    title="{{ message.subject.category.name }}" 
+                                    href="{{ path('claro_forum_subjects', { 'category': message.subject.category.id }) }}"
+                                >
+                                    {{ message.subject.category.name | truncate(20) }}
+                                 </a>
+                            </li>
+                            <li>
+                                <a 
+                                    class="link-subject" 
+                                    title="{{ message.getSubject().getTitle() }}" 
+                                    href="{{ _path('claro_forum_messages', {'subject': message.getSubject().getId() }) }}">
+                                    {{ message.getSubject().getTitle() | truncate(80) }}
+                                </a>
+                            </li>
+                        </ul>
+                        </p>
                     </div>
                 </li>
             {% endfor %}
         </ul>
-
     </div>
 {% else %}
     {{ 'no_forum_widget_message'|trans({}, 'widget') }}


### PR DESCRIPTION
(and truncate message text)

It looks like that 
![widgetforum](https://cloud.githubusercontent.com/assets/4488016/2732997/12f9ca3c-c641-11e3-9760-950902050e14.png)
